### PR TITLE
Automatically decorate shared view data

### DIFF
--- a/src/McCool/LaravelAutoPresenter/LaravelAutoPresenterServiceProvider.php
+++ b/src/McCool/LaravelAutoPresenter/LaravelAutoPresenterServiceProvider.php
@@ -29,7 +29,8 @@ class LaravelAutoPresenterServiceProvider extends ServiceProvider
         $app = $this->app;
 
         Event::listen('content.rendering', function($view) use ($app) {
-            $viewData  = $view->getData();
+            $sharedData = $view->getEnvironment()->getShared();
+            $viewData = array_merge($sharedData, $view->getData());
 
             if ( ! $viewData) {
                 return;


### PR DESCRIPTION
Currently the shared view data doesn't get automatically decorated. I have added an extra line to include the shared view data automatically in the decoration process.
