### PR TITLE
Catch and ignore empty presenter class name.

### DIFF
--- a/src/McCool/LaravelAutoPresenter/PresenterDecorator.php
+++ b/src/McCool/LaravelAutoPresenter/PresenterDecorator.php
@@ -83,6 +83,10 @@ class PresenterDecorator
 
         $presenterClass = $atom->getPresenter();
 
+        if (empty($presenterClass)) {
+            return $atom;
+        }
+        
         if ( ! class_exists($presenterClass)) {
             throw new PresenterNotFoundException($presenterClass);
         }


### PR DESCRIPTION
Quietly ignore any undefined presenter class.
