### PR TITLE
Support JsonSerializable to remove 'resource'.

### DIFF
--- a/src/McCool/LaravelAutoPresenter/BasePresenter.php
+++ b/src/McCool/LaravelAutoPresenter/BasePresenter.php
@@ -1,6 +1,6 @@
 <?php namespace McCool\LaravelAutoPresenter;
 
-class BasePresenter implements \ArrayAccess
+class BasePresenter implements \ArrayAccess, \JsonSerializable
 {
     /**
     * The resource that is the object that was decorated.
@@ -89,4 +89,15 @@ class BasePresenter implements \ArrayAccess
     {
         unset($this->resource[$key]);
     }
+    
+	/**
+	 * Convert the object into something JSON serializable.
+	 *
+	 * @return array
+	 */
+	public function jsonSerialize()
+	{
+		return $this->resource;
+	}
+
 }


### PR DESCRIPTION
As shown in https://github.com/ShawnMcCool/laravel-auto-presenter/issues/21, using json_encode() on a presenter wrapped entity results in the internal 'resource' element being visible.

Incorporating support for the JsonSerializable interface (http://uk3.php.net/manual/en/class.jsonserializable.php),  fixes this.

At least for me.

NOTE: PHP V5.4.0+ only - so I don't know how you want to incorporate this into the current release - or if you want to at all.

If there is a way, then that would be great!
