### PR TITLE
Ensure that properties available through __get and __isset magic methods

### DIFF
--- a/src/BasePresenter.php
+++ b/src/BasePresenter.php
@@ -40,7 +40,7 @@ abstract class BasePresenter
      */
     public function __get($key)
     {
-        if (property_exists($this->wrappedObject, $key)) {
+        if (property_exists($this->wrappedObject, $key) || isset($this->wrappedObject->$key)) {
             return $this->wrappedObject->$key;
         }
 

--- a/tests/BasePresenterTest.php
+++ b/tests/BasePresenterTest.php
@@ -38,6 +38,12 @@ class BasePresenterTest extends TestCase
         $this->assertEquals('bazinga', $presenter->myProperty);
     }
 
+    public function testMagicMethodProperty()
+    {
+        $presenter = new DecoratedAtomPresenter($this->decoratedAtom);
+        $this->assertEquals('woop', $presenter->testProperty);
+    }
+
     /**
      * @covers presenter::thisMethodDoesntExist
      * @expectedException \McCool\LaravelAutoPresenter\MethodNotFound

--- a/tests/Stubs/DecoratedAtom.php
+++ b/tests/Stubs/DecoratedAtom.php
@@ -14,4 +14,20 @@ class DecoratedAtom implements HasPresenter
     {
         return DecoratedAtomPresenter::class;
     }
+
+    /**
+     * __get properties should work too
+     */
+    public function __get($key)
+    {
+        if ($key == 'testProperty')
+            return 'woop';
+        else
+            return $this->$key;
+    }
+
+    public function __isset($key)
+    {
+        return ( $key == 'testProperty' || !is_null($this->$key) );
+    }
 }


### PR DESCRIPTION
This is a fix for #39. I had to make an executive decision to use `isset()` – for Eloquent models this will be fine. Other classes will need to define the corresponding magic methods, but this is a fringe case.

Tests included.
