### PR TITLE
Don't try to decorate a model unless it extends HasPresenter

### DIFF
--- a/src/Decorators/AtomDecorator.php
+++ b/src/Decorators/AtomDecorator.php
@@ -76,7 +76,9 @@ class AtomDecorator extends BaseDecorator implements DecoratorInterface
                 $model = $this->createDecorator('Collection')->decorate($model);
                 $atom->setRelation($relationName, $model);
             } else {
-                $atom->setRelation($relationName, $this->decorate($model));
+                if ($model instanceof HasPresenter) {
+                    $atom->setRelation($relationName, $this->decorate($model));
+                }
             }
         }
 

--- a/src/LaravelAutoPresenterServiceProvider.php
+++ b/src/LaravelAutoPresenterServiceProvider.php
@@ -66,7 +66,9 @@ class LaravelAutoPresenterServiceProvider extends ServiceProvider
             if ($viewData = array_merge($view->getFactory()->getShared(), $view->getData())) {
                 $decorator = $app['autopresenter'];
                 foreach ($viewData as $key => $value) {
-                    $view[$key] = $decorator->decorate($value);
+                    if ($value instanceof HasPresenter) {
+                        $view[$key] = $decorator->decorate($value);
+                    }
                 }
             }
         });

--- a/src/LaravelAutoPresenterServiceProvider.php
+++ b/src/LaravelAutoPresenterServiceProvider.php
@@ -66,9 +66,7 @@ class LaravelAutoPresenterServiceProvider extends ServiceProvider
             if ($viewData = array_merge($view->getFactory()->getShared(), $view->getData())) {
                 $decorator = $app['autopresenter'];
                 foreach ($viewData as $key => $value) {
-                    if ($value instanceof HasPresenter) {
-                        $view[$key] = $decorator->decorate($value);
-                    }
+                    $view[$key] = $decorator->decorate($value);
                 }
             }
         });


### PR DESCRIPTION
This makes sure that `PresenterDecorator::decorate()` is only called on models that extend the HasPresenter interface.  This is a work-around for #71 to avoid an infinite loop when used with jenssegers/laravel-mongodb.