### PR TITLE
ArrayAccess for presenters and serialization with models

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,55 @@ class Post extends Model implements HasPresenter
 
 Now, with no additional changes our view will show the date in the desired format.
 
+### Array Access
+
+If you want to access your presenter methods as array keys, add the `ArrayAccessTrait` to your *presenter* and make sure it implements the `ArrayAccess` interface.
+
+```php
+use Carbon\Carbon;
+use McCool\LaravelAutoPresenter\BasePresenter;
+
+use ArrayAccess;
+use McCool\LaravelAutoPresenter\Traits\ArrayAccessTrait;
+
+class PostPresenter extends BasePresenter implements ArrayAccess
+{
+       use ArrayAccessTrait;
+...
+```
+
+That will now let you access your `published_at` method as...
+
+```twig
+@foreach($posts as $post)
+    <li>{{ $post['title'] }} - {{ $post['published_at']' }}</li>
+@endforeach
+```
+
+### Serialization
+
+If you want your presenter values to be available when the object has been serialized, setup your presenter as outlined in Array Access above and add the `SerializesPresentedValuesTrait` to your *model* along with a protected array called `presented` with the name of the methods you want to be included.
+
+```php
+use Example\Accounts\User;
+use Example\Blog\PostPresenter;
+use McCool\LaravelAutoPresenter\HasPresenter;
+use Illuminate\Database\Eloquent\Model;
+
+use McCool\LaravelAutoPresenter\Traits\SerializesPresentedValuesTrait;
+
+class Post extends Model implements HasPresenter
+{
+
+    use SerializesPresentedValuesTrait;
+
+
+    protected presented = ['published_at'];
+...
+```
+
+Now you can use those decorated values in queued jobs, like `Mail::queue`. This setup adds the benefit of being able to use the same view for queued emails and rendering views for the browser.
+
 
 ## Troubleshooting
 

--- a/src/Traits/ArrayAccessTrait.php
+++ b/src/Traits/ArrayAccessTrait.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace McCool\LaravelAutoPresenter\Traits;
+
+use BadMethodCallException;
+
+/**
+ * Class ArrayAccessTrait
+ * @package McCool\LaravelAutoPresenter\Traits
+ *
+ * Trait should be applied to a Presenter to allow for array access of the properties.
+ * Presenter MUST implement ArrayAccess!
+ */
+trait ArrayAccessTrait
+{
+
+
+	/**
+	 * (PHP 5 &gt;= 5.0.0)<br/>
+	 * Whether a offset exists
+	 * @link http://php.net/manual/en/arrayaccess.offsetexists.php
+	 *
+	 * @param mixed $offset <p>
+	 * An offset to check for.
+	 * </p>
+	 *
+	 * @return boolean true on success or false on failure.
+	 * </p>
+	 * <p>
+	 * The return value will be casted to boolean if non-boolean was returned.
+	 */
+	public function offsetExists($offset)
+	{
+		if(method_exists($this, $offset)){
+			return true;
+		} else {
+			return property_exists($this->wrappedObject, $offset);
+		}
+	}
+
+	/**
+	 * (PHP 5 &gt;= 5.0.0)<br/>
+	 * Offset to retrieve
+	 * @link http://php.net/manual/en/arrayaccess.offsetget.php
+	 *
+	 * @param mixed $offset <p>
+	 * The offset to retrieve.
+	 * </p>
+	 *
+	 * @return mixed Can return all value types.
+	 */
+	public function offsetGet($offset)
+	{
+		return $this->$offset;
+	}
+
+	/**
+	 * (PHP 5 &gt;= 5.0.0)<br/>
+	 * Offset to set
+	 * @link http://php.net/manual/en/arrayaccess.offsetset.php
+	 *
+	 * @param mixed $offset <p>
+	 * The offset to assign the value to.
+	 * </p>
+	 * @param mixed $value <p>
+	 * The value to set.
+	 * </p>
+	 *
+	 * @return void
+	 */
+	public function offsetSet($offset, $value)
+	{
+		throw new BadMethodCallException('Can not use presenter array access for writing');
+	}
+
+	/**
+	 * (PHP 5 &gt;= 5.0.0)<br/>
+	 * Offset to unset
+	 * @link http://php.net/manual/en/arrayaccess.offsetunset.php
+	 *
+	 * @param mixed $offset <p>
+	 * The offset to unset.
+	 * </p>
+	 *
+	 * @return void
+	 */
+	public function offsetUnset($offset)
+	{
+		throw new BadMethodCallException('Can not use presenter array access for writing');
+	}
+
+}

--- a/src/Traits/SerializesPresentedValuesTrait.php
+++ b/src/Traits/SerializesPresentedValuesTrait.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace McCool\LaravelAutoPresenter\Traits;
+
+use McCool\LaravelAutoPresenter\HasPresenter;
+
+/**
+ * Class SerializesPresentedValuesTrait
+ * @package McCool\LaravelAutoPresenter\Traits
+ *
+ * @property $presented array an array of property names to include when serialized
+ *
+ * Trait should be applied to the Model being decorated. Works with the ArrayAccessTrait on presenters to be able
+ * to access decorated values once the model has been serialized (like within queued events).
+ */
+trait SerializesPresentedValuesTrait
+{
+
+	/**
+	 * Intercept calls to the models toArray function to inject presented values
+	 *
+	 * @return array
+	 */
+	public function toArray()
+	{
+		$model = parent::toArray();
+
+		if($this instanceof HasPresenter && count($this->presented)){
+			$presenter_class = $this->getPresenterClass();
+			$presenter = new $presenter_class($this);
+
+			$presented = [];
+			foreach ($this->presented as $key) {
+				$presented[$key] = $presenter->{$key}();
+			}
+
+			$all = array_merge($model, $presented);
+
+			return $all;
+		} else {
+			return $model;
+		}
+	}
+}

--- a/tests/BasePresenterArrayAccessTest.php
+++ b/tests/BasePresenterArrayAccessTest.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * This file is part of Laravel Auto Presenter.
+ *
+ * (c) Shawn McCool <shawn@heybigname.com>
+ * (c) Graham Campbell <graham@alt-three.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace McCool\Tests;
+
+use McCool\LaravelAutoPresenter\Exceptions\MethodNotFoundException;
+use McCool\Tests\Stubs\DecoratedAtomArrayAccess;
+use McCool\Tests\Stubs\DecoratedAtomArrayAccessPresenter;
+
+class BasePresenterArrayAccessTest extends AbstractTestCase
+{
+    private $decoratedAtom;
+
+    /**
+     * @before
+     */
+    public function setUpProperties()
+    {
+        $this->decoratedAtom = $this->app->make(DecoratedAtomArrayAccess::class);
+    }
+
+    public function testResourceIsReturned()
+    {
+        $presenter = new DecoratedAtomArrayAccessPresenter($this->decoratedAtom);
+        $this->assertSame($this->decoratedAtom, $presenter->getWrappedObject());
+    }
+
+    public function testResourceAttributeDeference()
+    {
+        $presenter = new DecoratedAtomArrayAccessPresenter($this->decoratedAtom);
+        $this->assertSame(DecoratedAtomArrayAccessPresenter::class, $presenter->getPresenterClass());
+    }
+
+    public function testPresenterMethodDeference()
+    {
+        $presenter = new DecoratedAtomArrayAccessPresenter($this->decoratedAtom);
+        $this->assertSame('Primer', $presenter['favoriteMovie']);
+    }
+
+    public function testResourcePropertyViaMagicMethod()
+    {
+        $presenter = new DecoratedAtomArrayAccessPresenter($this->decoratedAtom);
+        $this->assertSame('bazinga', $presenter['myProperty']);
+    }
+
+    public function testMagicMethodProperty()
+    {
+        $presenter = new DecoratedAtomArrayAccessPresenter($this->decoratedAtom);
+        $this->assertSame('woop', $presenter['testProperty']);
+    }
+
+    /**
+     * @expectedException \McCool\LaravelAutoPresenter\Exceptions\MethodNotFoundException
+     */
+    public function testResourceMethodNotFoundExceptionThrowsException()
+    {
+        try {
+            $presenter = new DecoratedAtomArrayAccessPresenter($this->decoratedAtom);
+            $presenter->thisMethodDoesntExist();
+        } catch (MethodNotFoundException $e) {
+            $method = 'thisMethodDoesntExist';
+            $class = DecoratedAtomArrayAccessPresenter::class;
+            $this->assertSame("The method '$method' was not found on the presenter class '$class'.", $e->getMessage());
+            $this->assertSame($method, $e->getMethod());
+            $this->assertSame($class, $e->getClass());
+            throw $e;
+        }
+    }
+
+    public function testIsSet()
+    {
+        $presenter = new DecoratedAtomArrayAccessPresenter($this->decoratedAtom);
+        $this->assertTrue(isset($presenter['myProperty']));
+        $this->assertTrue(isset($presenter['favoriteMovie']));
+    }
+
+    public function testToString()
+    {
+        $presenter = new DecoratedAtomArrayAccessPresenter($this->decoratedAtom);
+        $this->assertSame('hello there', (string) $presenter);
+    }
+}

--- a/tests/Functional/ViewDataArrayAccessTest.php
+++ b/tests/Functional/ViewDataArrayAccessTest.php
@@ -1,0 +1,127 @@
+<?php
+
+/*
+ * This file is part of Laravel Auto Presenter.
+ *
+ * (c) Shawn McCool <shawn@heybigname.com>
+ * (c) Graham Campbell <graham@alt-three.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace McCool\Tests\Functional;
+
+use Exception;
+use Illuminate\Support\Facades\Schema;
+use McCool\Tests\AbstractTestCase;
+use McCool\Tests\Stubs\ModelStubArrayAccess;
+
+class ViewDataArrayAccessTest extends AbstractTestCase
+{
+    /**
+     * Setup the application environment.
+     *
+     * @param \Illuminate\Contracts\Foundation\Application $app
+     *
+     * @return void
+     */
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app->view->addNamespace('stubs', realpath(__DIR__.'/stubs'));
+    }
+
+    public function testBasicSetup()
+    {
+        // make a new dummy model
+        $model = new ModelStubArrayAccess();
+
+        // set the foo attribute
+        $model->foo = 'hi';
+
+        // create a new view, with the model
+        $view = $this->app['view']->make('stubs::test')->withModel($model);
+
+        // check nothing has been modified yet
+        $this->assertInstanceOf('McCool\Tests\Stubs\ModelStubArrayAccess', $view->model);
+        $this->assertSame('hi', $view->model['foo']);
+
+        // render the view
+        $view->render();
+
+        // check that the model was decorated
+        $this->assertInstanceOf('McCool\Tests\Stubs\ModelPresenterArrayAccess', $view->model);
+        $this->assertSame('hi there', $view->model['foo']);
+
+        // render the view again
+        $view->render();
+
+        // check everything is still the same
+        $this->assertInstanceOf('McCool\Tests\Stubs\ModelPresenterArrayAccess', $view->model);
+        $this->assertSame('hi there', $view->model['foo']);
+    }
+
+    public function testSimpleCollection()
+    {
+        try {
+            $this->setupAndSeedDatabase();
+            $view = $this->app['view']->make('stubs::test')->withModels(ModelStubArrayAccess::all());
+            $view->render();
+            $this->assertCount(3, $view->models);
+            $this->assertInstanceOf('McCool\Tests\Stubs\ModelPresenterArrayAccess', $view->models[0]);
+            $this->assertSame('hello there', $view->models[0]['foo']);
+            $this->assertInstanceOf('McCool\Tests\Stubs\ModelPresenterArrayAccess', $view->models[1]);
+            $this->assertSame('herro there', $view->models[1]['foo']);
+            $this->assertInstanceOf('McCool\Tests\Stubs\ModelPresenterArrayAccess', $view->models[2]);
+            $this->assertSame('herro there', $view->models[2]['foo']);
+        } catch (Exception $e) {
+            throw $e;
+        } finally {
+            Schema::drop('stubs');
+        }
+    }
+
+    public function testGroupedCollection()
+    {
+        try {
+            $this->setupAndSeedDatabase();
+            $view = $this->app['view']->make('stubs::test')->withModels(ModelStubArrayAccess::all()->groupBy('foo'));
+            $view->render();
+            $this->assertCount(2, $view->models);
+            $this->assertCount(1, $view->models['hello']);
+            $this->assertInstanceOf('McCool\Tests\Stubs\ModelPresenterArrayAccess', $view->models['hello'][0]);
+            $this->assertSame('hello there', $view->models['hello'][0]['foo']);
+            $this->assertCount(2, $view->models['herro']);
+            $this->assertInstanceOf('McCool\Tests\Stubs\ModelPresenterArrayAccess', $view->models['herro'][0]);
+            $this->assertSame('herro there', $view->models['herro'][0]['foo']);
+            $this->assertInstanceOf('McCool\Tests\Stubs\ModelPresenterArrayAccess', $view->models['herro'][1]);
+            $this->assertSame('herro there', $view->models['herro'][1]['foo']);
+        } catch (Exception $e) {
+            throw $e;
+        } finally {
+            Schema::drop('stubs');
+        }
+    }
+
+    protected function setupAndSeedDatabase()
+    {
+        Schema::create('stubs', function ($table) {
+            $table->string('foo');
+            $table->timestamps();
+        });
+
+        $model = new ModelStubArrayAccess();
+        $model->foo = 'hello';
+        $model->save();
+
+        $model = new ModelStubArrayAccess();
+        $model->foo = 'herro';
+        $model->save();
+
+        $model = new ModelStubArrayAccess();
+        $model->foo = 'herro';
+        $model->save();
+    }
+}

--- a/tests/SerializeTest.php
+++ b/tests/SerializeTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace McCool\Tests;
+
+
+use McCool\Tests\Stubs\ModelStubSerialize;
+
+class SerializeTest extends AbstractTestCase
+{
+
+	public function testSerializeHasPresentedValue(){
+		$model = new ModelStubSerialize();
+		$model->foo = 'hello';
+
+		$arr = $model->toArray();
+		$this->assertSame('hello there', $arr['foo']);
+	}
+}

--- a/tests/Stubs/DecoratedAtomArrayAccess.php
+++ b/tests/Stubs/DecoratedAtomArrayAccess.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of Laravel Auto Presenter.
+ *
+ * (c) Shawn McCool <shawn@heybigname.com>
+ * (c) Graham Campbell <graham@alt-three.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace McCool\Tests\Stubs;
+
+use McCool\LaravelAutoPresenter\HasPresenter;
+
+class DecoratedAtomArrayAccess implements HasPresenter
+{
+    public $myProperty = 'bazinga';
+
+    public function getPresenterClass()
+    {
+        return DecoratedAtomArrayAccessPresenter::class;
+    }
+
+    public function __get($key)
+    {
+        if ($key == 'testProperty') {
+            return 'woop';
+        }
+
+        return $this->$key;
+    }
+
+    public function __toString()
+    {
+        return 'hello there';
+    }
+}

--- a/tests/Stubs/DecoratedAtomArrayAccessPresenter.php
+++ b/tests/Stubs/DecoratedAtomArrayAccessPresenter.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of Laravel Auto Presenter.
+ *
+ * (c) Shawn McCool <shawn@heybigname.com>
+ * (c) Graham Campbell <graham@alt-three.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace McCool\Tests\Stubs;
+
+use ArrayAccess;
+use McCool\LaravelAutoPresenter\BasePresenter;
+use McCool\LaravelAutoPresenter\Traits\ArrayAccessTrait;
+
+class DecoratedAtomArrayAccessPresenter extends BasePresenter implements ArrayAccess
+{
+	use ArrayAccessTrait;
+
+    public function favoriteMovie()
+    {
+        return 'Primer';
+    }
+}

--- a/tests/Stubs/ModelPresenterArrayAccess.php
+++ b/tests/Stubs/ModelPresenterArrayAccess.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of Laravel Auto Presenter.
+ *
+ * (c) Shawn McCool <shawn@heybigname.com>
+ * (c) Graham Campbell <graham@alt-three.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace McCool\Tests\Stubs;
+
+use ArrayAccess;
+use McCool\LaravelAutoPresenter\BasePresenter;
+use McCool\LaravelAutoPresenter\Traits\ArrayAccessTrait;
+
+class ModelPresenterArrayAccess extends BasePresenter implements ArrayAccess
+{
+	use ArrayAccessTrait;
+
+    public function foo()
+    {
+        return $this->getWrappedObject()->foo.' there';
+    }
+}

--- a/tests/Stubs/ModelStubArrayAccess.php
+++ b/tests/Stubs/ModelStubArrayAccess.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of Laravel Auto Presenter.
+ *
+ * (c) Shawn McCool <shawn@heybigname.com>
+ * (c) Graham Campbell <graham@alt-three.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace McCool\Tests\Stubs;
+
+use Illuminate\Database\Eloquent\Model;
+use McCool\LaravelAutoPresenter\HasPresenter;
+
+class ModelStubArrayAccess extends Model implements HasPresenter
+{
+    protected $table = 'stubs';
+
+    public function getPresenterClass()
+    {
+        return ModelPresenterArrayAccess::class;
+    }
+}

--- a/tests/Stubs/ModelStubSerialize.php
+++ b/tests/Stubs/ModelStubSerialize.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of Laravel Auto Presenter.
+ *
+ * (c) Shawn McCool <shawn@heybigname.com>
+ * (c) Graham Campbell <graham@alt-three.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace McCool\Tests\Stubs;
+
+use Illuminate\Database\Eloquent\Model;
+use McCool\LaravelAutoPresenter\HasPresenter;
+use McCool\LaravelAutoPresenter\Traits\SerializesPresentedValuesTrait;
+
+class ModelStubSerialize extends Model implements HasPresenter
+{
+	use SerializesPresentedValuesTrait;
+
+	protected $table = 'stubs';
+
+	protected $presented = ['foo'];
+
+    public function getPresenterClass()
+    {
+        return ModelPresenterArrayAccess::class;
+    }
+}


### PR DESCRIPTION
Created traits that gives ArrayAccess compatibility for presenters and another for models to add presenter data to their serialized data. This allows for the use of presenter data within queued jobs like Mail:queue