### PR TITLE
Implement UrlRoutable for getRouteKey

### DIFF
--- a/src/BasePresenter.php
+++ b/src/BasePresenter.php
@@ -13,8 +13,9 @@
 namespace McCool\LaravelAutoPresenter;
 
 use McCool\LaravelAutoPresenter\Exceptions\MethodNotFoundException;
+use Illuminate\Contracts\Routing\UrlRoutable;
 
-abstract class BasePresenter
+abstract class BasePresenter implements UrlRoutable
 {
     /**
      * The resource that is the object that was decorated.
@@ -43,6 +44,26 @@ abstract class BasePresenter
     public function getWrappedObject()
     {
         return $this->wrappedObject;
+    }
+
+    /**
+     * Get the value of the model's route key.
+     *
+     * @return mixed
+     */
+    public function getRouteKey()
+    {
+        return $this->wrappedObject->getRouteKey();
+    }
+
+    /**
+     * Get the route key for the model.
+     *
+     * @return string
+     */
+    public function getRouteKeyName()
+    {
+        return $this->wrappedObject->getRouteKeyName();
     }
 
     /**

--- a/src/BasePresenter.php
+++ b/src/BasePresenter.php
@@ -12,8 +12,8 @@
 
 namespace McCool\LaravelAutoPresenter;
 
-use McCool\LaravelAutoPresenter\Exceptions\MethodNotFoundException;
 use Illuminate\Contracts\Routing\UrlRoutable;
+use McCool\LaravelAutoPresenter\Exceptions\MethodNotFoundException;
 
 abstract class BasePresenter implements UrlRoutable
 {

--- a/src/Decorators/PaginatorDecorator.php
+++ b/src/Decorators/PaginatorDecorator.php
@@ -36,7 +36,7 @@ class PaginatorDecorator implements DecoratorInterface
     {
         $this->autoPresenter = $autoPresenter;
     }
-    
+
     /**
      * Can the subject be decorated?
      *

--- a/src/Decorators/PaginatorDecorator.php
+++ b/src/Decorators/PaginatorDecorator.php
@@ -36,6 +36,7 @@ class PaginatorDecorator implements DecoratorInterface
     {
         $this->autoPresenter = $autoPresenter;
     }
+    
     /**
      * Can the subject be decorated?
      *


### PR DESCRIPTION
Implemented UrlRoutable in order to fix the ability to pass an entire model to the route() function and let it decide what attribute to use as the route parameter.

The underlying Laravel system checks in Illuminate\Routing\UrlGenerator on line 392 whether the parameter passed is an instance of UrlRoutable. Prior to this change, it would turn the object into JSON and use that as the route parameter.