### PR TITLE
Add method to set the wrappedObject's properties.

### DIFF
--- a/src/BasePresenter.php
+++ b/src/BasePresenter.php
@@ -104,6 +104,17 @@ abstract class BasePresenter implements UrlRoutable
     }
 
     /**
+     * Magic method to be able to set properties to the decorated object.
+     *
+     * @param string $name
+     * @param mixed  $value
+     */
+    public function __set($name, $value)
+    {
+        $this->wrappedObject->{$name} = $value;
+    }
+
+    /**
      * Is the key set on either the presenter or the wrapped object?
      *
      * @param string $key


### PR DESCRIPTION
Add the ability to set properties on the wrapped object.

I need to register another decorator but it's a model that's already been decorated, so I can not set the wrapped object's properties.

https://github.com/flashtag/flashtag/blob/master/app/Data/Presenters/Decorators/PostFieldDecorator.php#L63

This solves that.