### PR TITLE
Allow container to build decorators, so they can be swapped out

### DIFF
--- a/src/AutoPresenterServiceProvider.php
+++ b/src/AutoPresenterServiceProvider.php
@@ -93,9 +93,9 @@ class AutoPresenterServiceProvider extends ServiceProvider
         $app->singleton('autopresenter', function (Container $app) {
             $autoPresenter = new AutoPresenter();
 
-            $autoPresenter->register(new AtomDecorator($autoPresenter, $app));
-            $autoPresenter->register(new ArrayDecorator($autoPresenter));
-            $autoPresenter->register(new PaginatorDecorator($autoPresenter));
+            $autoPresenter->register($app->make(AtomDecorator::class, ['autoPresenter' => $autoPresenter, 'app' => $app]));
+            $autoPresenter->register($app->make(ArrayDecorator::class, ['autoPresenter' => $autoPresenter]));
+            $autoPresenter->register($app->make(PaginatorDecorator::class, ['autoPresenter' => $autoPresenter]));
 
             return $autoPresenter;
         });


### PR DESCRIPTION
…with bindings.

This is another solution to my problem, that allows me to decorate an Eloquent Model without having to make the Presenter mutable.


As seen here:

https://github.com/flashtag/flashtag/blob/master/app/Data/Providers/DataServiceProvider.php#L54

I did have a solution that just registered another decorator and cloned and re-decorated the model, but it was not getting applied until after the view rendered, so had to ditch that option.
