### PR TITLE
Allow undecorated models to attempt to decorate their relations.

### DIFF
--- a/src/Decorators/AtomDecorator.php
+++ b/src/Decorators/AtomDecorator.php
@@ -79,7 +79,7 @@ class AtomDecorator implements DecoratorInterface
             }
         }
 
-        if (! $subject instanceof HasPresenter) {
+        if (!$subject instanceof HasPresenter) {
             return $subject;
         }
 

--- a/src/Decorators/AtomDecorator.php
+++ b/src/Decorators/AtomDecorator.php
@@ -57,7 +57,7 @@ class AtomDecorator implements DecoratorInterface
      */
     public function canDecorate($subject)
     {
-        return $subject instanceof HasPresenter;
+        return $subject instanceof HasPresenter || $subject instanceof Model;
     }
 
     /**
@@ -77,6 +77,10 @@ class AtomDecorator implements DecoratorInterface
             foreach ($subject->getRelations() as $relationName => $model) {
                 $subject->setRelation($relationName, $this->autoPresenter->decorate($model));
             }
+        }
+
+        if (! $subject instanceof HasPresenter) {
+            return $subject;
         }
 
         if (!class_exists($presenter = $subject->getPresenterClass())) {

--- a/tests/Stubs/UndecoratedModelStub.php
+++ b/tests/Stubs/UndecoratedModelStub.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of Laravel Auto Presenter.
+ *
+ * (c) Shawn McCool <shawn@heybigname.com>
+ * (c) Graham Campbell <graham@alt-three.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace McCool\Tests\Stubs;
+
+use Illuminate\Database\Eloquent\Model;
+
+class UndecoratedModelStub extends Model
+{
+    protected $table = 'stubs';
+}


### PR DESCRIPTION
This resolves issue #89.

Given the following code snippets:
```
class Book extends Model
{
    public function chapters()
    {
        return $this->hasMany(Chapter::class);
    }
}

class Chapter extends Model implements HasPresenter
{
    // getPresenterClass() implementation
}

$books = Book::with('chapters')->find(1);
view('books.index', compact('books'));
```

In this example, even though the `Chapter` model is setup properly to be decorated, it will not be decorated because the parent class that is sent to the view, `Book`, is not decorated.

This same issue occurs if any `Model` in a string of relationships is not setup for decoration. Any descendants of the undecorated `Model` will remain undecorated, even if they are properly setup for decoration.

This PR resolves the issue by allowing the `AtomDecorator` to handle `Model` instances that do not implement the `HasPresenter` interface. If the `Model` does not implement the `HasPresenter` interface, it will simply be returned as is from the decorator, after it attempts to decorate the model's relations.

Please let me know if there are any issues or if something doesn't look correct. Thank you for your time!